### PR TITLE
npm does not understand 'latest' as a version anymore. Removed unused require of sys module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     },
     "main": "./lib/jsonpath",
     "dependencies": {
-        "underscore": "latest"
+        "underscore": "1.3.x"
     },
     "devDependencies": {
-        "nodeunit": "latest"
+        "nodeunit": "0.6.x"
     }
 }

--- a/test/test.intermixed.arr.js
+++ b/test/test.intermixed.arr.js
@@ -1,5 +1,4 @@
 var jsonpath = require("../").eval,
-    sys = require('sys'),
     testCase = require('nodeunit').testCase
 
 // tests based on examples at http://goessner.net/articles/JsonPath/


### PR DESCRIPTION
npm WARN unmet dependency node_modules/JSONPath requires underscore@'latest' but will load
