### PR TITLE
Fix global leak of ret in JSONPath.normalize()

### DIFF
--- a/lib/jsonpath.js
+++ b/lib/jsonpath.js
@@ -20,7 +20,7 @@ function jsonPath(obj, expr, arg) {
          }
 
          var subx = [];
-         ret = expr.replace(/[\['](\??\(.*?\))[\]']/g, function($0,$1){return "[#"+(subx.push($1)-1)+"]";})
+         var ret = expr.replace(/[\['](\??\(.*?\))[\]']/g, function($0,$1){return "[#"+(subx.push($1)-1)+"]";})
                     .replace(/'?\.'?|\['?/g, ";")
                     .replace(/;;;|;;/g, ";..;")
                     .replace(/;$|'?\]|'$/g, "")


### PR DESCRIPTION
Fix global leak of ret in JSONPath.normalize().

While writing mocha tests around some use of JSONPath, it found a global declaration of ret in normalize() versus var.  There appears to be no reason why ret would be a global in this context, and in other versions of the codebase--on google code--the value is just returned raw because there's no caching in place anyway.
