### PR TITLE
Make the library compatible with browser environment and get rid of underscore dependency

### DIFF
--- a/lib/jsonpath.js
+++ b/lib/jsonpath.js
@@ -4,9 +4,25 @@
  * Licensed under the MIT (MIT-LICENSE.txt) licence.
  */
 
-var vm = require('vm'),
-    _ = require('underscore');
+(function(exports, require) {
+
+// Keep compatibility with old browsers
+if (!Array.isArray) {
+  Array.isArray = function (vArg) {
+    return Object.prototype.toString.call(vArg) === "[object Array]";
+  };
+}
+
+// Make sure to know if we are in real node or not (the `require` variable
+// could actually be require.js, for example.
+var isNode = false;
+if (typeof module !== 'undefined' && module.exports) {
+  isNode = true;
+}
+
+var vm = isNode ? require('vm') : { runInNewContext: eval };
 exports.eval = jsonPath;
+
 var cache = {};
 function jsonPath(obj, expr, arg) {
    var P = {
@@ -40,15 +56,15 @@ function jsonPath(obj, expr, arg) {
                  P.result[P.result.length] = P.asPath(p);
              }
              else {
-                 if(_.isArray(v) && P.flatten) {
+                 if(Array.isArray(v) && P.flatten) {
                      if(!P.result) P.result = [];
-                     if(!_.isArray(P.result)) P.result = [P.result];
+                     if(!Array.isArray(P.result)) P.result = [P.result];
                      P.result = P.result.concat(v);
                  }
                  else {
                      if(P.result) {
-                         if(!_.isArray(P.result)) P.result = [P.result];
-                         if(_.isArray(v) && P.flatten) {
+                         if(!Array.isArray(P.result)) P.result = [P.result];
+                         if(Array.isArray(v) && P.flatten) {
                              P.result = P.result.concat(v);
                          }
                          else {
@@ -127,7 +143,8 @@ function jsonPath(obj, expr, arg) {
    var $ = obj;
    if (expr && obj && (P.resultType == "VALUE" || P.resultType == "PATH")) {
       P.trace(P.normalize(expr).replace(/^\$;/,""), obj, "$");
-      if(!_.isArray(P.result) && P.wrap) P.result = [P.result];
+      if(!Array.isArray(P.result) && P.wrap) P.result = [P.result];
       return P.result ? P.result : false;
    }
-} 
+}
+})(typeof exports === 'undefined' ? this['jsonPath'] = {} : exports);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A JS implementation of JSONPath",
     "contributors": [
         {
-            "name": "Prof. Gšssner",
+            "name": "Prof. GÃ¶ssner",
             "email": "stefan.goessner@fh-dortmund.de"
         },
         {
@@ -16,15 +16,12 @@
             "email": "mike@brevoort.com"
         }
     ],
-    "version": "0.9.1",
+    "version": "0.9.2",
     "repository": {
         "type": "git",
         "url": "git://github.com/s3u/JSONPath.git"
     },
     "main": "./lib/jsonpath",
-    "dependencies": {
-        "underscore": "1.3.x"
-    },
     "devDependencies": {
         "nodeunit": "0.6.x"
     }


### PR DESCRIPTION
This patch makes JSONPath compatible with the browser environment without changing its usage for Node.js. It also gets rid of the underscore.js dependency, which was only used for the `Array.isArray` static method, which is now polyfilled in case the target platform doesn't contain the method.
