### PR TITLE
Add underscore#isArray shim and browser section to package.json to reduce browserified size

### DIFF
--- a/browser/shim/underscore-is-array.js
+++ b/browser/shim/underscore-is-array.js
@@ -1,0 +1,9 @@
+/* jshint -W116 */
+var nativeIsArray = Array.isArray;
+
+// Is a given value an array?
+// Delegates to ECMA5's native Array.isArray
+exports.isArray = nativeIsArray || function(obj) {
+  return Object.prototype.toString.call(obj) == '[object Array]';
+};
+/* jshint +W116 */

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     },
     "devDependencies": {
         "nodeunit": "0.6.x"
+    },
+    "browser": {
+        "underscore": "./browser/shim/underscore-is-array.js"
     }
 }


### PR DESCRIPTION
This PR reduces the size of the library from 50 K to 8 K when it is browserified (see [Browserify](http://browserify.org/)).  It does so by adding a shim for the underscore depencency that only incldudes the isArray method (as this is the only method used from underscore). The code for the shim is more or less copied from underscore. The shim is only used when the module is browserified, in node, the original underscore dependency is used. 

Actually, #15 is the better fix for this, so if #15 ever gets merged, you can close this one without merging. In case you want to keep the underscore dependency for node (though I see no good reason to want this), this PR provides an alternative that makes this fine module nicer for browserify users.

Looking forward to hear your thoughts on either #15 or this one :-)
