### PR TITLE
add package.json to module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.6",
   "main": "dist/index-node-cjs.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "browser": "./dist/index-browser-esm.js",
       "umd": "./dist/index-browser-umd.js",


### PR DESCRIPTION
## PR description

Hello, I have this error with `node@14.16.1`, `webpack@5.30.0` and `jsonpath-plus@5.0.6`:

> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports"

The `pakage.json` file is missing from `exports` and `webpack` is trying to require the file. I found the explanation on the `yargs` repository which had the same issue: https://github.com/yargs/yargs/pull/1818

## Checklist

- [x] - Added tests
- [x] - Ran `npm test`, ensuring linting passes
- [x] - Adjust README documentation if relevant
