### PR TITLE
Fix file extensions in package.json

### DIFF
--- a/docs/ts/index.html
+++ b/docs/ts/index.html
@@ -137,13 +137,13 @@
 				<a href="#browser" id="browser" style="color: inherit; text-decoration: none;">
 					<h3>Browser</h3>
 				</a>
-				<p>For browser usage you can directly include <code>dist/index-browser-umd.js</code>; no Browserify
+				<p>For browser usage you can directly include <code>dist/index-browser-umd.cjs</code>; no Browserify
 				magic is necessary:</p>
 				<pre><code class="language-html"><span style="color: #008000">&lt;!-- Polyfill recommended by Babel for items not covered for older</span>
 <span style="color: #008000">      browsers in dist --&gt;</span>
 <span style="color: #800000">&lt;script</span><span style="color: #000000FF"> </span><span style="color: #FF0000">src</span><span style="color: #000000FF">=</span><span style="color: #0000FF">&quot;node_modules/core-js-bundle/minified.js&quot;</span><span style="color: #800000">&gt;&lt;/script&gt;</span>
 
-<span style="color: #800000">&lt;script</span><span style="color: #000000FF"> </span><span style="color: #FF0000">src</span><span style="color: #000000FF">=</span><span style="color: #0000FF">&quot;node_modules/jsonpath-plus/dist/index-browser-umd.js&quot;</span><span style="color: #800000">&gt;&lt;/script&gt;</span>
+<span style="color: #800000">&lt;script</span><span style="color: #000000FF"> </span><span style="color: #FF0000">src</span><span style="color: #000000FF">=</span><span style="color: #0000FF">&quot;node_modules/jsonpath-plus/dist/index-browser-umd.cjs&quot;</span><span style="color: #800000">&gt;&lt;/script&gt;</span>
 
 <span style="color: #800000">&lt;script&gt;</span>
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "jsonpath-plus",
   "version": "6.0.0",
   "type": "module",
-  "main": "dist/index-node-cjs.js",
+  "main": "dist/index-node-cjs.cjs",
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -14,7 +14,7 @@
       "default": "./dist/index-browser-esm.js"
     }
   },
-  "module": "dist/index-node-esm.mjs",
+  "module": "dist/index-node-esm.js",
   "browser": "dist/index-browser-esm.js",
   "types": "./src/jsonpath.d.ts",
   "description": "A JS implementation of JSONPath with some additional operators",


### PR DESCRIPTION
## PR description

After recent renaming of dist/* files, some file names were not updated
in package.json. This causes issues, specifically in node.js when you do
`import { JSONPath } from 'jsonpath-plus'`, you'll get an error because
it tries to access a non-existent file based on package.json `main` field.

## Checklist

- [ ] - Added tests
- [x] - Ran `npm test`, ensuring linting passes
- [ ] - Adjust README documentation if relevant
