### PR TITLE
perf: improve evaluation speed of conditional queries

### DIFF
--- a/src/jsonpath-browser.js
+++ b/src/jsonpath-browser.js
@@ -32,14 +32,24 @@ const moveToAnotherArray = function (source, target, conditionCb) {
     }
 };
 
-JSONPath.prototype.vm = {
+/**
+ * In-browser replacement for NodeJS' VM.Script.
+ */
+class Script {
     /**
      * @param {string} expr Expression to evaluate
+     */
+    constructor (expr) {
+        this.code = expr;
+    }
+
+    /**
      * @param {PlainObject} context Object whose items will be added
      *   to evaluation
      * @returns {EvaluatedResult} Result of evaluated code
      */
-    runInNewContext (expr, context) {
+    runInNewContext (context) {
+        let expr = this.code;
         const keys = Object.keys(context);
         const funcs = [];
         moveToAnotherArray(keys, funcs, (key) => {
@@ -81,6 +91,10 @@ JSONPath.prototype.vm = {
         // eslint-disable-next-line no-new-func
         return (new Function(...keys, code))(...values);
     }
+}
+
+JSONPath.prototype.vm = {
+    Script
 };
 
 export {JSONPath};

--- a/test/test.errors.js
+++ b/test/test.errors.js
@@ -20,7 +20,7 @@ checkBuiltInVMAndNodeVM(function (vmType, setBuiltInState) {
         it('should throw with a bad filter', () => {
             expect(() => {
                 jsonpath({json: {book: []}, path: '$..[?(@.category === category)]'});
-            }).to.throw(Error, 'jsonPath: category is not defined: _$_v.category === category');
+            }).to.throw(Error, 'jsonPath: category is not defined: @.category === category');
         });
 
         it('should throw with a bad result type', () => {


### PR DESCRIPTION
## PR description
Use NodeJS' vm.Script class to cache the script that the context needs
to be evaluated against. This provides large speed improvements (~50%)
when a path contains conditional or JS logic.

To evaluate the performance improvements, I ran 
[json-querying-performance-testing](https://github.com/andykais/json-querying-performance-testing) against a 16" 2019 MacBook Pro with 
an i9. Three runs were averaged together, with deltas calculated against
main.

```
smallCityLots
┌────────────────────┬──────────┬──────────┬─────────────┐
│      (index)       │ shallow  │   deep   │ conditional │
├────────────────────┼──────────┼──────────┼─────────────┤
│   jsonpath-plus    │  0.4027  │  0.3462  │   0.2765    │
├────────────────────┼──────────┼──────────┼─────────────┤
│ jsonpath-plus (PR) │  0.4085  │  0.3501  │   0.1416    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     Time Delta     │ +0.0058  │ +0.0139  │  -0.1349    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     % Speedup      │ -1.4403% │ -1.1265% │  +48.788%   │
└────────────────────┴──────────┴──────────┴─────────────┘
mediumCityLots
┌────────────────────┬──────────┬──────────┬─────────────┐
│      (index)       │ shallow  │   deep   │ conditional │
├────────────────────┼──────────┼──────────┼─────────────┤
│   jsonpath-plus    │  0.7341  │  0.7493  │   0.5278    │
├────────────────────┼──────────┼──────────┼─────────────┤
│ jsonpath-plus (PR) │  0.7424  │  0.7605  │   0.2579    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     Time Delta     │ +0.0083  │ +0.0112  │  -0.2699    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     % Speedup      │ -1.1306% │ -1.4947% │  +51.137%   │
└────────────────────┴──────────┴──────────┴─────────────┘
largeCityLots
┌────────────────────┬──────────┬──────────┬─────────────┐
│      (index)       │ shallow  │   deep   │ conditional │
├────────────────────┼──────────┼──────────┼─────────────┤
│   jsonpath-plus    │  1.9973  │  2.0534  │   1.1102    │
├────────────────────┼──────────┼──────────┼─────────────┤
│ jsonpath-plus (PR) │  2.0169  │  2.0846  │   0.5036    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     Time Delta     │ +0.0196  │ +0.0312  │  -0.6066    │
├────────────────────┼──────────┼──────────┼─────────────┤
│     % Speedup      │ -0.9813% │ -1.5194% │  +54.639%   │
└────────────────────┴──────────┴──────────┴─────────────┘
```

One interesting thing to note is there does appear to be a slight (<2%)
performance regression on shallow and deep queries. I think given the
purpose of this library (advanced JSON Path selectors, with full logic), 
that the slight performance regression is well worth the large (~50%) 
performance increase for conditional queries.

In a real world project, with a wide range of selector complexity, I saw
~24% speed improvement.

## Checklist

- [X] - Added tests
- [X] - Ran `npm test`, ensuring linting passes
- [X] - Adjust README documentation if relevant
