### PR TITLE
chore: add types to exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./src/jsonpath.d.ts",
       "browser": "./dist/index-browser-esm.js",
       "umd": "./dist/index-browser-umd.cjs",
       "import": "./dist/index-node-esm.js",


### PR DESCRIPTION
Fixes the types for newer versions of Node and TypeScript.

[See here for relevant section of TypeScript docs.](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing)