### PR TITLE
perf: optimize walk method by 10-34%

### DIFF
--- a/src/jsonpath.js
+++ b/src/jsonpath.js
@@ -352,33 +352,28 @@ JSONPath.prototype._trace = function (
             hasArrExpr));
     // eslint-disable-next-line unicorn/prefer-switch -- Part of larger `if`
     } else if (loc === '*') { // all child properties
-        this._walk(
-            loc, x, val, path, parent, parentPropName, callback,
-            (m, l, _x, v, p, par, pr, cb) => {
-                addRet(this._trace(unshift(m, _x), v, p, par, pr, cb,
-                    true, true));
-            }
-        );
+        this._walk(val, (m) => {
+            addRet(this._trace(
+                x, val[m], push(path, m), val, m, callback, true, true
+            ));
+        });
     } else if (loc === '..') { // all descendent parent properties
         // Check remaining expression with val's immediate children
         addRet(
             this._trace(x, val, path, parent, parentPropName, callback,
                 hasArrExpr)
         );
-        this._walk(
-            loc, x, val, path, parent, parentPropName, callback,
-            (m, l, _x, v, p, par, pr, cb) => {
-                // We don't join m and x here because we only want parents,
-                //   not scalar values
-                if (typeof v[m] === 'object') {
-                    // Keep going with recursive descent on val's
-                    //   object children
-                    addRet(this._trace(
-                        unshift(l, _x), v[m], push(p, m), v, m, cb, true
-                    ));
-                }
+        this._walk(val, (m) => {
+            // We don't join m and x here because we only want parents,
+            //   not scalar values
+            if (typeof val[m] === 'object') {
+                // Keep going with recursive descent on val's
+                //   object children
+                addRet(this._trace(
+                    expr.slice(), val[m], push(path, m), val, m, callback, true
+                ));
             }
-        );
+        });
     // The parent sel computation is handled in the frame above using the
     // ancestor object of val
     } else if (loc === '^') {
@@ -408,15 +403,13 @@ JSONPath.prototype._trace = function (
         if (this.currPreventEval) {
             throw new Error('Eval [?(expr)] prevented in JSONPath expression.');
         }
-        this._walk(
-            loc, x, val, path, parent, parentPropName, callback,
-            (m, l, _x, v, p, par, pr, cb) => {
-                if (this._eval(l.replace(/^\?\((.*?)\)$/u, '$1'), v[m], m, p, par, pr)) {
-                    addRet(this._trace(unshift(m, _x), v, p, par, pr, cb,
-                        true));
-                }
+        const safeLoc = loc.replace(/^\?\((.*?)\)$/u, '$1');
+        this._walk(val, (m) => {
+            if (this._eval(safeLoc, val[m], m, path, parent, parentPropName)) {
+                addRet(this._trace(x, val[m], push(path, m), val, m, callback,
+                    true));
             }
-        );
+        });
     } else if (loc[0] === '(') { // [(expr)] (dynamic property/index)
         if (this.currPreventEval) {
             throw new Error('Eval [(expr)] prevented in JSONPath expression.');
@@ -543,17 +536,15 @@ JSONPath.prototype._trace = function (
     return ret;
 };
 
-JSONPath.prototype._walk = function (
-    loc, expr, val, path, parent, parentPropName, callback, f
-) {
+JSONPath.prototype._walk = function (val, f) {
     if (Array.isArray(val)) {
         const n = val.length;
         for (let i = 0; i < n; i++) {
-            f(i, loc, expr, val, path, parent, parentPropName, callback);
+            f(i);
         }
     } else if (val && typeof val === 'object') {
         Object.keys(val).forEach((m) => {
-            f(m, loc, expr, val, path, parent, parentPropName, callback);
+            f(m);
         });
     }
 };


### PR DESCRIPTION
The walk method now only takes the parameters it actually needs, which
gives a performance bump to due to less copying & passing of parameters
to the walk method.

Running json-querying-performance-testing, this change produced the
following speed improvements compared to v7.1.0.

```
smallCityLots
┌───────────────┬───────────┬────────────┬─────────────┐
│    (index)    │  shallow  │    deep    │ conditional │
├───────────────┼───────────┼────────────┼─────────────┤
│ jsonpath-plus │   0.0641  │   0.3249   │   0.1199    │
├───────────────┼───────────┼────────────┼─────────────┤
│  jsonpath-pr  │   0.0439  │   0.2930   │   0.0850    │
├───────────────┼───────────┼────────────┼─────────────┤
│  Time Delta   │  -0.0202  │  -0.0319   │  -0.0349    │
├───────────────┼───────────┼────────────┼─────────────┤
│   % Change    │ -31.5133% │  -9.8184%  │ -29.1076%   │
└───────────────┴───────────┴────────────┴─────────────┘
mediumCityLots
┌───────────────┬───────────┬────────────┬─────────────┐
│    (index)    │  shallow  │    deep    │ conditional │
├───────────────┼───────────┼────────────┼─────────────┤
│ jsonpath-plus │   0.092   │   0.6739   │   0.2409    │
├───────────────┼───────────┼────────────┼─────────────┤
│  jsonpath-pr  │   0.0659  │   0.5443   │   0.1672    │
├───────────────┼───────────┼────────────┼─────────────┤
│  Time Delta   │  -0.0261  │  -0.1296   │  -0.0737    │
├───────────────┼───────────┼────────────┼─────────────┤
│   % Change    │ -28.3696% │ -19.2313%  │ -30.5936%   │
└───────────────┴───────────┴────────────┴─────────────┘
largeCityLots
┌───────────────┬───────────┬────────────┬─────────────┐
│    (index)    │  shallow  │    deep    │ conditional │
├───────────────┼───────────┼────────────┼─────────────┤
│ jsonpath-plus │   0.1910  │   1.8946   │   0.4900    │
├───────────────┼───────────┼────────────┼─────────────┤
│  jsonpath-pr  │   0.1347  │   1.6538   │   0.3230    │
├───────────────┼───────────┼────────────┼─────────────┤
│  Time Delta   │   0.0563  │  -0.2408   │  -0.1670    │
├───────────────┼───────────┼────────────┼─────────────┤
│   % Change    │ -29.4764% │ -12.7098%  │ -34.0816%   │
└───────────────┴───────────┴────────────┴─────────────┘
```

## PR description

<!-- Add the description of your PR here -->


## Checklist

- [X] - Added tests
- [X] - Ran `npm test`, ensuring linting passes
- [X] - Adjust README documentation if relevant
