### PR TITLE
fix browser-test

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -8,14 +8,14 @@
         <!-- Testing dependencies -->
         <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
         <script src="../node_modules/mocha/mocha.js"></script>
-        <script src="../node_modules/chai/chai.js"></script>
     </head>
     <body>
         <h1>JSONPath Tests</h1>
         <div id="mocha"></div>
 
         <script type="module">
-        import {JSONPath} from '../src/jsonpath-browser.js';
+        import * as chai from '../node_modules/chai/chai.js'
+        import {JSONPath} from '../dist/index-browser-esm.js';
 
         mocha.setup('bdd');
         window.assert = chai.assert;


### PR DESCRIPTION
broken by commit: https://github.com/JSONPath-Plus/JSONPath/commit/7dc82dc2800b3d327262035536593c43c4fe4d50

## PR description

<!-- Add the description of your PR here -->
Kind of insignificant, but `browser-test` script was broken since https://github.com/JSONPath-Plus/JSONPath/commit/7dc82dc2800b3d327262035536593c43c4fe4d50 because since [chai-5.0.0](https://github.com/chaijs/chai/releases/tag/v5.0.0), chai only supports ES modules.

## Checklist

- [x] - Added tests
- [x] - Ran `npm test`, ensuring linting passes
- [x] - Adjust README documentation if relevant
