### PR TITLE
fix(filter): allow bare @ adjacent to an operator without whitespace

### DIFF
--- a/src/jsonpath.js
+++ b/src/jsonpath.js
@@ -649,7 +649,7 @@ JSONPath.prototype._eval = function (
             .replaceAll('@parent', '_$_parent')
             .replaceAll('@property', '_$_property')
             .replaceAll('@root', '_$_root')
-            .replaceAll(/@([.\s)[])/gu, '_$_v$1');
+            .replaceAll(/@([-.\s)[<>=!%*/+&|])/gu, '_$_v$1');
         if (containsPath) {
             script = script.replaceAll('@path', '_$_path');
         }

--- a/test/test.at_and_dollar.js
+++ b/test/test.at_and_dollar.js
@@ -52,4 +52,12 @@ describe('JSONPath - At and Dollar sign', function () {
         const result = jsonpath({json, path: "$.a[?(@property === 'b' && @ < 1)]", wrap: false});
         assert.deepEqual(result, expected);
     });
+
+    it('bare @ adjacent to an operator (no whitespace)', () => {
+        const json = [0, 1, 2, 3];
+        assert.deepEqual(jsonpath({json, path: '$[?(@>1)]'}), [2, 3]);
+        assert.deepEqual(jsonpath({json, path: '$[?(@<2)]'}), [0, 1]);
+        assert.deepEqual(jsonpath({json, path: '$[?(@===2)]'}), [2]);
+        assert.deepEqual(jsonpath({json, path: '$[?(@!==2)]'}), [0, 1, 3]);
+    });
 });


### PR DESCRIPTION
### Bug

A filter with a bare `@` (the current node) placed directly against an operator, with no whitespace, fails to evaluate:

```js
JSONPath({json: [0, 1, 2, 3], path: '$[?(@>1)]'});
// Error: Unexpected "@" at character 0   (safe eval)
// Error: Invalid or unexpected token     (native eval)
```

The same query works only if a space is added: `$[?(@ > 1)]`.

### Cause

In `_eval`, the current-node token `@` is rewritten to the sandbox variable `_$_v` by:

```js
.replaceAll(/@([.\s)[])/gu, '_$_v$1');
```

The character class only allows `@` to be followed by `.`, whitespace, `)` or `[`. When `@` is immediately followed by a comparison or arithmetic operator (`>`, `<`, `==`, `!=`, `%`, `+`, `-`, `*`, `/`, `&`, `|`), it is left as a literal `@`, so the compiled filter script begins with `@` and neither the safe (jsep) nor the native (`vm`) evaluator can parse it.

### Fix

Add those operator characters to the delimiter class:

```js
.replaceAll(/@([-.\s)[<>=!%*/+&|])/gu, '_$_v$1');
```

`@` inside identifiers and quoted keys is still protected (it is only rewritten when followed by an operator/delimiter, never a word character), so cases like `@['@tag']` are unaffected.

Adds a regression test covering `@>`, `@<`, `@===` and `@!==` with no surrounding whitespace. Full suite passes and lint is clean.
